### PR TITLE
Fix coverage months

### DIFF
--- a/api/documentation/swagger.json
+++ b/api/documentation/swagger.json
@@ -274,7 +274,7 @@
           "required": true
         },
         "month": {
-          "$ref": "#/definitions/coverage-month",
+          "type": "string",
           "description": "The coverage month that the payment was applied to",
           "required": true
         }

--- a/api/routes/client.js
+++ b/api/routes/client.js
@@ -33,40 +33,28 @@ const clients = {
       ],
       paymentHistory: [
         {
-          amount: 100,
-          received: Date.UTC(2017, 1, 9),
-          applied: Date.UTC(2017, 1, 10),
-          month: {
-            start: Date.UTC(2017, 1, 10),
-            end: Date.UTC(2017, 2, 9)
-          }
+          amount: 20,
+          received: Date.UTC(2017, 2, 10),
+          applied: Date.UTC(2017, 2, 11),
+          month: 'March 2017'
         },
         {
           amount: 100,
-          received: Date.UTC(2017, 0, 9),
-          applied: Date.UTC(2017, 0, 10),
-          month: {
-            start: Date.UTC(2017, 0, 10),
-            end: Date.UTC(2017, 1, 9)
-          }
+          received: Date.UTC(2017, 0, 28),
+          applied: Date.UTC(2017, 0, 30),
+          month: 'February 2017'
         },
         {
           amount: 50,
-          received: Date.UTC(2016, 11, 1),
-          applied: Date.UTC(2016, 11, 1),
-          month: {
-            start: Date.UTC(2016, 11, 1),
-            end: Date.UTC(2016, 11, 31)
-          }
+          received: Date.UTC(2017, 0, 16),
+          applied: Date.UTC(2017, 0, 17),
+          month: 'January 2017'
         },
         {
           amount: 100,
           received: Date.UTC(2016, 9, 15),
           applied: Date.UTC(2016, 9, 16),
-          month: {
-            start: Date.UTC(2016, 9, 16),
-            end: Date.UTC(2016, 10, 15)
-          }
+          month: 'December 2016'
         }
       ]
     }

--- a/web/src/components/spenddown/paymentHistory/row.js
+++ b/web/src/components/spenddown/paymentHistory/row.js
@@ -38,7 +38,7 @@ export default function paymentHistoryRow(props) {
                 <h6>Applied to</h6>
               </th>
               <td>
-                <Date value={props.month.start} /> - <Date value={props.month.end} />
+                {props.month}
               </td>
             </tr>
           </tbody>


### PR DESCRIPTION
For spend-down, months of coverage are not date ranges (e.g., January 15-February 15) but rather whole calendar months.  This PR updates the client schema to represent coverage months as a string (e.g., "February 2017") and makes associated changes to the data and the web application.