### PR TITLE
Test endpoints

### DIFF
--- a/api/documentation/swagger.json
+++ b/api/documentation/swagger.json
@@ -112,8 +112,7 @@
       "properties": {
         "realName": {
           "type": "string",
-          "description": "The user's real name as an arbitrary string.",
-          "required": true
+          "description": "The user's real name as an arbitrary string."
         },
         "role": {
           "type": "string",
@@ -122,47 +121,41 @@
             "provider",
             "state"
           ],
-          "description": "The user's role in the system",
-          "required": true
+          "description": "The user's role in the system"
         },
         "eligibility": {
-          "$ref": "#/definitions/Eligibility",
-          "required": true
+          "$ref": "#/definitions/Eligibility"
         },
         "token": {
           "type": "string",
-          "description": "JWT token representing the user",
-          "required": true
+          "description": "JWT token representing the user"
         }
-      }
+      },
+      "required": [ "realName", "description", "eligibility", "token" ]
     },
     "Client": {
       "type": "object",
       "properties": {
         "dcn": {
           "type": "string",
-          "description": "The department client number for this client",
-          "required": true
+          "description": "The department client number for this client"
         },
         "people": {
-          "$ref": "#/definitions/people",
-          "required": true
+          "$ref": "#/definitions/people"
         },
         "eligibility": {
           "type": "string",
-          "description": "Medicaid eligibility code/descriptive text",
-          "required": true
+          "description": "Medicaid eligibility code/descriptive text"
         },
         "coverage": {
           "type": "string",
-          "description": "Coverage code/descriptive text",
-          "required": true
+          "description": "Coverage code/descriptive text"
         },
         "spenddown": {
-          "$ref": "#/definitions/spenddown",
-          "required": true
+          "$ref": "#/definitions/spenddown"
         }
-      }
+      },
+      "required": [ "dcn", "people", "eligibility", "coverage", "spenddown" ]
     },
     "people": {
       "type": "object",
@@ -170,31 +163,28 @@
       "properties": {
         "primary": {
           "type": "string",
-          "description": "The full name of the primary client for the DCN",
-          "required": true
+          "description": "The full name of the primary client for the DCN"
         },
         "others": {
           "type": "array",
           "description": "Full names of all other members on the DCN",
           "items": {
             "type": "string"
-          },
-          "required": true
+          }
         },
         "address": {
           "type": "array",
           "description": "Address of the client; each item in the array corresponds to an address line",
           "items": {
             "type": "string"
-          },
-          "required": true
+          }
         },
         "phone": {
           "type": "string",
-          "description": "Client's phone number",
-          "required": true
+          "description": "Client's phone number"
         }
-      }
+      },
+      "required": [ "primary", "others", "address", "phone" ]
     },
     "spenddown": {
       "type": "object",
@@ -202,31 +192,28 @@
       "properties": {
         "monthlyAmount": {
           "type": "number",
-          "description": "The total spend down dollar amount due each month",
-          "required": true
+          "description": "The total spend down dollar amount due each month"
         },
         "owed": {
           "type": "number",
-          "description": "The total spend down dollar amount still owed for coverage to begin",
-          "required": true
+          "description": "The total spend down dollar amount still owed for coverage to begin"
         },
         "contributions": {
           "type": "array",
           "descriptions": "Contributions towards the client's spend down",
           "items": {
             "$ref": "#/definitions/spenddown-contribution"
-          },
-          "required": true
+          }
         },
         "paymentHistory": {
           "type": "array",
           "description": "History of payments",
           "items": {
             "$ref": "#/definitions/payment"
-          },
-          "required": true
+          }
         }
-      }
+      },
+      "required": [ "monthlyAmount", "owed", "contributions", "paymentHistory" ]
     },
     "spenddown-contribution": {
       "type": "object",
@@ -234,8 +221,7 @@
       "properties": {
         "amount": {
           "type": "number",
-          "description": "The dollar amount of the contribution",
-          "required": true
+          "description": "The dollar amount of the contribution"
         },
         "status": {
           "type": "string",
@@ -244,15 +230,14 @@
             "paid",
             "unpaid",
             "direct"
-          ],
-          "required": true
+          ]
         },
         "to": {
           "type": "string",
-          "description": "Who the contribution was paid to or incurred from, or absent for direct contributions",
-          "required": false
+          "description": "Who the contribution was paid to or incurred from, or absent for direct contributions"
         }
-      }
+      },
+      "required": [ "amount", "status" ]
     },
     "payment": {
       "type": "object",
@@ -260,45 +245,26 @@
       "properties": {
         "amount": {
           "type": "number",
-          "description": "The dollar amount of the payment",
-          "required": true
+          "description": "The dollar amount of the payment"
         },
         "received": {
           "$ref": "#/definitions/date",
-          "description": "The date the payment was received",
-          "required": true
+          "description": "The date the payment was received"
         },
         "applied": {
           "$ref": "#/definitions/date",
-          "description": "The date the payment was applied",
-          "required": true
+          "description": "The date the payment was applied"
         },
         "month": {
           "type": "string",
-          "description": "The coverage month that the payment was applied to",
-          "required": true
+          "description": "The coverage month that the payment was applied to"
         }
-      }
+      },
+      "required": [ "amount", "received", "applied", "month" ]
     },
     "date": {
       "type": "number",
       "description": "A data expressed in Javascript epoch time, as the milliseconds since midnight, January 1, 1970, UTC"
-    },
-    "coverage-month": {
-      "type": "object",
-      "description": "A start and end date describing one coverage month",
-      "properties": {
-        "start": {
-          "$ref": "#/definitions/date",
-          "description": "The start date of the month",
-          "required": true
-        },
-        "end": {
-          "$ref": "#/definitions/date",
-          "description": "The end date of the month",
-          "required": true
-        }
-      }
     },
     "Eligibility": {
       "type": "object",

--- a/api/middleware/cors.js
+++ b/api/middleware/cors.js
@@ -20,16 +20,19 @@ module.exports = function cors(app, schema) {
     if (pathSchema) {
       // Get the list of methods that this path supports,
       // and send that in the CORS response.
-      const supportedMethods = Object.keys(pathSchema).map(verb => verb.toUpperCase()).join(',');
-      res.header('Access-Control-Allow-Methods', supportedMethods);
+      const supportedMethods = Object.keys(pathSchema).map(verb => verb.toUpperCase());
+      // const supportedMethods = Object.keys(pathSchema).map(verb => verb.toUpperCase()).join(',');
+      res.header('Access-Control-Allow-Methods', supportedMethods.join(','));
       res.header('Access-Control-Allow-Origin', req.get('origin'));
       res.header('Access-Control-Allow-Headers', 'Accepts, Authorization, Content-Length, Content-Type');
 
       if (req.method === 'OPTIONS') {
         // If it's an OPTIONS request, just bail out here.
         res.sendStatus(200);
-      } else {
+      } else if (supportedMethods.includes(req.method)) {
         next();
+      } else {
+        res.sendStatus(405);
       }
     } else {
       // If the path doesn't exist, 404.

--- a/api/package.json
+++ b/api/package.json
@@ -5,9 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "node index.js",
-    "start-dev": "nodemon ./index.js",
-    "lint": "eslint --fix 'test/**/*.js' 'middleware/**/*.js' 'routes/**/*.js' *.js",
-    "test": "istanbul cover tape -- 'test/**/*.js' | tap-summary"
+    "start-dev": "nodemon ./index.js"
   },
   "keywords": [],
   "author": "",
@@ -19,16 +17,9 @@
     "jsonwebtoken": "^7.3.0"
   },
   "devDependencies": {
-    "eslint": "^3.17.1",
-    "eslint-config-airbnb-base": "^11.1.1",
-    "eslint-plugin-import": "^2.2.0",
-    "istanbul": "^0.4.5",
-    "nodemon": "^1.11.0",
-    "sinon": "^1.17.7",
-    "tap-summary": "^3.0.1",
-    "tape": "^4.6.3"
+    "nodemon": "^1.11.0"
   },
   "engines": {
-    "node": "~6.9.0"
+    "node": "^6.9.0"
   }
 }

--- a/api/test/endpoints.js
+++ b/api/test/endpoints.js
@@ -1,0 +1,113 @@
+/* eslint-disable import/no-extraneous-dependencies */
+const tape = require('tape');
+const fork = require('child_process').fork;
+const path = require('path');
+const request = require('request-promise-native');
+const swaggerParser = require('swagger-parser');
+const AJV = require('ajv');
+
+const ajv = new AJV();
+let swagger;
+let serverProcess;
+
+function methodIsUnsupported(methodName, test) {
+  request[methodName]('http://0.0.0.0:8000/client/dcn')
+    .then(() => {
+      test.fail('should not return successfully');
+      test.end();
+    })
+    .catch((err) => {
+      test.equal(err.response.statusCode, 405, 'returns a 405 error');
+      test.end();
+    })
+    .catch((err) => {
+      test.fail(err);
+      test.end();
+    });
+}
+
+function runTests() {
+  tape.test('api endpoints', (test) => {
+    test.test('/client/{department-client-number}...', (clientDCNTest) => {
+      clientDCNTest.test('get', (getTest) => {
+        getTest.test('with an invalid DCN', (invalidDCN) => {
+          request.get('http://0.0.0.0:8000/client/dcn')
+            .then(() => {
+              invalidDCN.fail('should not return successfully');
+              invalidDCN.end();
+            })
+            .catch((err) => {
+              invalidDCN.equal(err.response.statusCode, 404, 'returns a 404 error');
+              invalidDCN.end();
+            })
+            .catch((err) => {
+              invalidDCN.fail(err);
+              invalidDCN.end();
+            });
+        });
+
+        getTest.test('with a valid DCN', (validDCN) => {
+          request.get({ method: 'GET', uri: 'http://0.0.0.0:8000/client/123456789', resolveWithFullResponse: true })
+            .then((response) => {
+              validDCN.equal(response.statusCode, 200, 'returns a 200 HTTP status code');
+              const body = JSON.parse(response.body);
+              const validator = ajv.compile(swagger.paths['/client/{department-client-number}'].get.responses['200'].schema);
+              const valid = validator(body);
+              validDCN.ok(valid, 'body should be valid according to swagger spec');
+              validDCN.notOk(validator.errors, 'no errors');
+              validDCN.end();
+            })
+            .catch((err) => {
+              test.fail(err);
+              validDCN.end();
+            });
+        });
+
+        getTest.end();
+      });
+
+      clientDCNTest.test('put', (putTest) => {
+        methodIsUnsupported('put', putTest);
+      });
+
+      clientDCNTest.test('post', (postTest) => {
+        methodIsUnsupported('post', postTest);
+      });
+
+      clientDCNTest.test('delete', (deleteTest) => {
+        methodIsUnsupported('del', deleteTest);
+      });
+
+      clientDCNTest.end();
+    });
+
+    test.end();
+  });
+
+  // lean on tape's serial nature to teardown the server process
+  tape.test('HTTP server teardown', (t) => {
+    if (serverProcess) {
+      serverProcess.kill('SIGTERM');
+    }
+    t.end();
+  });
+}
+
+tape.test('HTTP server setup', (t) => {
+  // instantiate the HTTP server so we can actually hit its endpoints
+  serverProcess = fork(path.join(__dirname, '../index'));
+
+  // wait a second so it can actually crank up
+  setTimeout(() => {
+    // load swagger so we can validate against it
+    swaggerParser.dereference(path.join(__dirname, '../documentation/swagger.json'))
+      .then((parsedSwagger) => {
+        swagger = parsedSwagger;
+
+        // once we've got the swagger loaded, run the inner tests and
+        // mark this setup as complete
+        runTests();
+        t.end();
+      });
+  }, 1000);
+});

--- a/api/test/middleware/cors.js
+++ b/api/test/middleware/cors.js
@@ -69,6 +69,7 @@ tape.test('middleware/cors', (test) => {
     headersTest.test('where the path has parameters', (parameterPathTest) => {
       const mocks = utils.getMockHandlerArguments();
       mocks.req.url = '/test3/param';
+      mocks.req.method = 'GET';
       handler(mocks.req, mocks.res, mocks.next);
       // This is the URL that should have been matched, so that's the one we should check against
       mocks.req.url = '/test3/{parameter}';

--- a/api/test/middleware/cors.js
+++ b/api/test/middleware/cors.js
@@ -78,11 +78,28 @@ tape.test('middleware/cors', (test) => {
     });
 
     headersTest.test('where the method is not OPTIONS', (notOptionsRequestTest) => {
-      const mocks = utils.getMockHandlerArguments();
-      mocks.req.url = '/test1';
-      handler(mocks.req, mocks.res, mocks.next);
-      setsHeaders(mocks.req, mocks.res, notOptionsRequestTest);
-      notOptionsRequestTest.ok(mocks.next.calledOnce, 'next is called');
+      notOptionsRequestTest.test('where the method is not supported', (unsupportedMethodTest) => {
+        const mocks = utils.getMockHandlerArguments();
+        mocks.req.url = '/test1';
+        mocks.req.method = 'PUT';
+        handler(mocks.req, mocks.res, mocks.next);
+        setsHeaders(mocks.req, mocks.res, unsupportedMethodTest);
+        unsupportedMethodTest.ok(mocks.res.sendStatus.calledOnce, 'HTTP response status is set once');
+        unsupportedMethodTest.ok(mocks.res.sendStatus.calledWith(405), 'HTTP status code 405 is sent');
+        unsupportedMethodTest.ok(mocks.next.notCalled, 'next is not called');
+        unsupportedMethodTest.end();
+      });
+
+      notOptionsRequestTest.test('where the method is supported', (supportedMethodTest) => {
+        const mocks = utils.getMockHandlerArguments();
+        mocks.req.url = '/test1';
+        mocks.req.method = 'GET';
+        handler(mocks.req, mocks.res, mocks.next);
+        setsHeaders(mocks.req, mocks.res, supportedMethodTest);
+        supportedMethodTest.ok(mocks.next.calledOnce, 'next is called');
+        supportedMethodTest.end();
+      });
+
       notOptionsRequestTest.end();
     });
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,10 @@
     "eslint-plugin-jsx-a11y": "^4.0.0",
     "eslint-plugin-react": "^6.10.0",
     "istanbul": "^0.4.5",
+    "request": "^2.81.0",
+    "request-promise-native": "^1.0.3",
     "sinon": "^1.17.7",
+    "swagger-parser": "^3.4.1",
     "tape": "^4.6.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "## Running locally",
   "main": "index.js",
   "scripts": {
-    "lint": "eslint --fix 'api/middleware/**/*.js' 'api/routes/**/*.js' 'api/*.js' 'web/src/**/*.js'",
+    "lint": "eslint --fix 'api/middleware/**/*.js' 'api/routes/**/*.js' 'api/*.js' 'api/test/**/*.js' 'web/src/**/*.js'",
     "test": "istanbul cover tape -- 'api/test/**/*.js'"
   },
   "repository": {

--- a/web/package.json
+++ b/web/package.json
@@ -6,9 +6,7 @@
   "scripts": {
     "build": "mkdir -p dist && cp src/index.html dist/ && webpack -p",
     "watch": "webpack --watch",
-    "lint": "eslint --fix 'src/**/*.js'",
-    "start": "webpack-dev-server --host 0.0.0.0 --port 8000 --content-base src/",
-    "test": ":"
+    "start": "webpack-dev-server --host 0.0.0.0 --port 8000 --content-base src/"
   },
   "keywords": [],
   "author": "",
@@ -33,11 +31,6 @@
     "babel-preset-es2015": "^6.22.0",
     "babel-preset-react": "^6.23.0",
     "css-loader": "^0.27.3",
-    "eslint": "^3.16.1",
-    "eslint-config-airbnb": "^14.1.0",
-    "eslint-plugin-import": "^2.2.0",
-    "eslint-plugin-jsx-a11y": "^4.0.0",
-    "eslint-plugin-react": "^6.10.0",
     "file-loader": "^0.10.1",
     "node-sass": "^4.5.0",
     "resolve-url-loader": "^2.0.2",


### PR DESCRIPTION
Makes some fixes to the Swagger (it wasn't strictly valid), but primarily adds tests to hit the API endpoints via HTTP calls to make sure what we're getting back is valid according to the Swagger spec and that we're getting back the response codes we expect.

~~Still needs...~~
~~- [ ] validate responses for defined non-success conditions (e.g., 404 on `/client/dcn`)~~
* For that 404, there's no return value specified.  The 404 is the whole thing.